### PR TITLE
Adds stop host command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -11,8 +11,6 @@ documentation = "https://docs.rs/wasmcloud-control-interface"
 readme = "README.md"
 keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
-# don't include build.rs on crates.io build
-exclude = ["build.rs"]
 
 [dependencies]
 async-trait = "0.1"
@@ -31,4 +29,4 @@ serde_json = "1.0.60"
 uuid = {version = "0.8", features  = ["serde", "v4"]}
 wascap = "0.6.0"
 wasmbus-rpc = "0.5.3"
-wasmcloud-interface-lattice-control = "0.1.0"
+wasmcloud-interface-lattice-control = "0.2.1"

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -51,6 +51,10 @@ pub mod commands {
     pub fn update_actor(nsprefix: &Option<String>, host: &str) -> String {
         format!("{}.cmd.{}.upd", prefix(nsprefix), host)
     }
+
+    pub fn stop_host(nsprefix: &Option<String>, host: &str) -> String {
+        format!("{}.cmd.{}.stop", prefix(nsprefix), host)
+    }
 }
 
 pub mod queries {


### PR DESCRIPTION
Once this is merged and a subsequent release is pushed, this client can then be used by the `wasmcloud:latticecontrol` capability provider.