### PR TITLE
add count to startActor and stopActor commands; bump crate to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -29,4 +29,4 @@ serde_json = "1.0.60"
 uuid = {version = "0.8", features  = ["serde", "v4"]}
 wascap = "0.6.0"
 wasmbus-rpc = "0.5.3"
-wasmcloud-interface-lattice-control = "0.2.1"
+wasmcloud-interface-lattice-control = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use nats::asynk::Connection;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, time::Duration};
 use sub_stream::SubscriptionStream;
-pub use wasmbus_rpc::{core::LinkDefinition, RpcClient};
+pub use wasmbus_rpc::core::LinkDefinition;
 
 type Result<T> = ::std::result::Result<T, Box<dyn ::std::error::Error + Send + Sync>>;
 
@@ -135,6 +135,7 @@ impl Client {
         &self,
         host_id: &str,
         actor_ref: &str,
+        count: u16,
         annotations: Option<HashMap<String, String>>,
     ) -> Result<CtlOperationAck> {
         let subject = broker::commands::start_actor(&self.nsprefix, host_id);
@@ -143,6 +144,7 @@ impl Client {
             actor_ref: actor_ref.to_string(),
             host_id: host_id.to_string(),
             annotations,
+            count,
         })?;
         match self
             .nc
@@ -354,7 +356,7 @@ impl Client {
         let bytes = json_serialize(StopActorCommand {
             host_id: host_id.to_string(),
             actor_ref: actor_ref.to_string(),
-            count: Some(count),
+            count,
             annotations,
         })?;
         match self


### PR DESCRIPTION
This PR depends on https://github.com/wasmCloud/interfaces/pull/43
   which bumps the lattice-control interface to v0.3.0


Signed-off-by: stevelr <steve@cosmonic.com>