### PR TITLE
Add support for publishing registry credential map to lattice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ serde_json = "1.0.60"
 uuid = {version = "0.8", features  = ["serde", "v4"]}
 wascap = "0.8.0"
 wasmbus-rpc = "0.7.1"
-wasmcloud-interface-lattice-control = "0.7.0"
+wasmcloud-interface-lattice-control = "0.8.0"

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -28,6 +28,10 @@ pub fn remove_link(ns_prefix: &Option<String>) -> String {
     format!("{}.linkdefs.del", prefix(ns_prefix))
 }
 
+pub fn publish_registries(ns_prefix: &Option<String>) -> String {
+    format!("{}.registries.put", prefix(ns_prefix))
+}
+
 pub mod commands {
     use super::prefix;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,26 @@ impl Client {
         }
     }
 
+    /// Publishes a registry credential map to the control interface of the lattice.
+    /// All hosts will be listening and all will overwrite their registry credential
+    /// map with the new information. It is highly recommended you use TLS connections
+    /// with NATS and isolate the control interface credentials when using this
+    /// function in production as the data contains secrets
+    pub async fn push_registries(&self, registries: RegistryCredentialMap) -> Result<()> {
+        let subject = broker::publish_registries(&self.nsprefix);
+        trace!("push_registries {}", &subject);
+        let bytes = json_serialize(&registries)?;
+        if let Err(e) = self
+            .nc
+            .request_timeout(&subject, &bytes, self.timeout)
+            .await
+        {
+            Err(format!("Failed to push registry credential map: {}", e).into())
+        } else {
+            Ok(())
+        }
+    }
+
     /// Publishes the link advertisement message to the lattice that is published when code invokes the `set_link`
     /// function on a `Host` struct instance. No confirmation or acknowledgement is available for this operation
     /// because it is publish-only.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,9 @@ impl Client {
     /// map with the new information. It is highly recommended you use TLS connections
     /// with NATS and isolate the control interface credentials when using this
     /// function in production as the data contains secrets
-    pub async fn push_registries(&self, registries: RegistryCredentialMap) -> Result<()> {
+    pub async fn put_registries(&self, registries: RegistryCredentialMap) -> Result<()> {
         let subject = broker::publish_registries(&self.nsprefix);
-        trace!("push_registries {}", &subject);
+        trace!("put_registries {}", &subject);
         let bytes = json_serialize(&registries)?;
         if let Err(e) = self
             .nc


### PR DESCRIPTION
Adds a function to the control interface client that publishes a registry credential map to a lattice.