### PR TITLE
add tracing to wasmcloud-control-interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -24,7 +24,8 @@ tokio = {version="1.9", features=["time"]}
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 tracing = "0.1.35"
+tracing-futures = "0.2"
 uuid = {version = "1.0.0", features  = ["serde", "v4"]}
 wascap = "0.8.0"
-wasmbus-rpc = "0.9.0"
-wasmcloud-interface-lattice-control = "0.12.0"
+wasmbus-rpc = {version = "0.9.0", features = ["otel"]}
+wasmcloud-interface-lattice-control = "0.12.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,8 @@ impl Client {
                         provider_configuration,
                     )
                     .await;
-                }).instrument(tracing::Span::current());
+                })
+                .instrument(tracing::Span::current());
             } else if error.is_empty() {
                 error = "No hosts detected in in no-host provider start.".to_string();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,6 +393,7 @@ impl Client {
             // If a host is found, start brackground request to start provider and return Ack
             let mut error = String::new();
             debug!("start_provider:deferred (no-host) request");
+            let current_span = tracing::Span::current();
             let host = match self.get_hosts().await {
                 Err(e) => {
                     error = format!("failed to query hosts for no-host provider start: {}", e);
@@ -413,9 +414,9 @@ impl Client {
                         annotations,
                         provider_configuration,
                     )
+                    .instrument(current_span)
                     .await;
-                })
-                .instrument(tracing::Span::current());
+                });
             } else if error.is_empty() {
                 error = "No hosts detected in in no-host provider start.".to_string();
             }


### PR DESCRIPTION
Dependent on 0.12.1 of the interface, to be released from: https://github.com/wasmCloud/interfaces/pull/80

Signed-off-by: Connor Smith <connor@cosmonic.com>