### PR TITLE
Flushy control interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -14,7 +14,7 @@ categories = ["wasm", "api-bindings"]
 
 [dependencies]
 async-trait = "0.1"
-async-nats = "0.15.0"
+async-nats = "0.17.0"
 data-encoding = "2.3.1"
 cloudevents-sdk = "0.4.0"
 futures = "0.3"


### PR DESCRIPTION
This:
- pulls in async-nats 0.17 and wasmbus-rpc 0.9.2 for performance improvements
- adds a `flush` after publishing to decrease latency

Signed-off-by: Connor Smith <connor@cosmonic.com>