### PR TITLE
Add `#[derive(Debug)]` to Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -13,7 +13,7 @@ keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
 
 [dependencies]
-async-nats = "0.18.0"
+async-nats = "0.19.0"
 cloudevents-sdk = "0.5.0"
 futures = "0.3"
 rmp-serde = "1.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ use wasmbus_rpc::otel::OtelHeaderInjector;
 type Result<T> = ::std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 /// Lattice control interface client
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     nc: async_nats::Client,
     topic_prefix: Option<String>,


### PR DESCRIPTION
Adds a `Debug` impl to `Client`. This is mainly to use for more helpful `wash` error messages. See https://github.com/wasmCloud/wash/pull/310.

Signed-off-by: Matt Wilkinson <matt@mattwilkinson.dev>