### PR TITLE
add registryType as required field to RegistryCredential

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"

--- a/src/types.rs
+++ b/src/types.rs
@@ -201,6 +201,9 @@ pub struct RegistryCredential {
     /// If supplied, username and password will be used for HTTP Basic authentication
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
+    /// The type of the registry (either "oci" or "bindle")
+    #[serde(rename = "registryType")]
+    pub registry_type: String,
 }
 
 /// A set of credentials to be used for fetching from specific registries


### PR DESCRIPTION
This is related to the [lattice control interface change](https://github.com/wasmCloud/interfaces/pull/91). The control interface client will now include a `registryType` field, removing the need for the host to try to guess the type of registry server on config updates

Signed-off-by: Connor Smith <connor@cosmonic.com>