### PR TITLE
bump to compatible versions of async-nats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"
@@ -13,7 +13,7 @@ keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
 
 [dependencies]
-async-nats = "0.22.1"
+async-nats = "0.23"
 cloudevents-sdk = "0.6.0"
 futures = "0.3"
 rmp-serde = "1.0.0"
@@ -22,4 +22,4 @@ serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 tracing = "0.1.37"
 tracing-futures = "0.2"
-wasmbus-rpc = { version = "0.11.1", features = [ "otel" ] }
+wasmbus-rpc = { version = "0.11.2", features = [ "otel" ] }


### PR DESCRIPTION
Can't compile on main currently because of incompatibilities with `HeaderMap` versions. Bumping to v0.23 here resolves it