### PR TITLE
add contract_id to provider descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.22.2"
+version = "0.22.3"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.dev"

--- a/src/types.rs
+++ b/src/types.rs
@@ -178,6 +178,9 @@ pub struct ProviderDescription {
     /// Image reference for this provider, if applicable
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub image_ref: Option<String>,
+    /// Provider's contract ID
+    #[serde(default)]
+    pub contract_id: String,
     /// Provider's link name
     #[serde(default)]
     pub link_name: String,


### PR DESCRIPTION
Related change to the host, adding the field to emitted inventories: https://github.com/wasmCloud/wasmcloud-otp/pull/515

To preserve backwards-compatibility, if the host doesn't emit the field, we default to an empty string

Signed-off-by: Connor Smith <connor@cosmonic.com>