### PR TITLE
Add log message when checking for KV bucket

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.23.0"
+version = "0.23.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use async_nats::{jetstream::kv::Store, Client};
+use tracing::debug;
 use wasmbus_rpc::core::LinkDefinition;
 
 use data_encoding::HEXUPPER;
@@ -25,7 +26,16 @@ pub(crate) async fn get_kv_store(
         async_nats::jetstream::new(nc)
     };
     let bucket = format!("{}{}", BUCKET_PREFIX, lattice_prefix);
-    jetstream.get_key_value(bucket).await.ok()
+    let store_opt = jetstream.get_key_value(bucket).await.ok();
+    match &store_opt {
+        Some(_) => {
+            debug!(%lattice_prefix, "Using direct bucket access for lattice metadata queries")
+        }
+        None => {
+            debug!(%lattice_prefix, "Using deprecated control interface commands for lattice metadata queries")
+        }
+    }
+    store_opt
 }
 
 pub(crate) async fn get_claims(store: &Store) -> Result<GetClaimsResponse> {

--- a/src/kv.rs
+++ b/src/kv.rs
@@ -40,19 +40,19 @@ pub(crate) async fn get_kv_store(
 
 pub(crate) async fn get_claims(store: &Store) -> Result<GetClaimsResponse> {
     let mut claims = Vec::new();
-    let mut entries = store.keys().await?;
-    while let Some(key) = entries.next() {
+    let entries = store.keys().await?;
+    for key in entries {
         if key.starts_with(CLAIMS_PREFIX) {
             add_claim(&mut claims, store.get(key).await?).await?;
         }
     }
-    Ok(GetClaimsResponse { claims: claims })
+    Ok(GetClaimsResponse { claims })
 }
 
 pub(crate) async fn get_links(store: &Store) -> Result<LinkDefinitionList> {
     let mut links = Vec::new();
-    let mut entries = store.keys().await?;
-    while let Some(key) = entries.next() {
+    let entries = store.keys().await?;
+    for key in entries {
         if key.starts_with(LINKDEF_PREFIX) {
             add_linkdef(&mut links, store.get(key).await?).await?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,7 @@ impl ClientBuilder {
 
     /// Sets the timeout for standard calls and RPC invocations used by the client. If not set, the default will be 2 seconds
     pub fn rpc_timeout(self, timeout: Duration) -> ClientBuilder {
-        ClientBuilder {
-            timeout: timeout,
-            ..self
-        }
+        ClientBuilder { timeout, ..self }
     }
 
     /// Sets the timeout for auction (scatter/gather) operations. If not set, the default will be 5 seconds


### PR DESCRIPTION
This PR adds a log message when the control interface client decides which method to use to query lattice metadata