### PR TITLE
Bumps rpc and nats version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.23.1"
+version = "0.24.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"
@@ -13,7 +13,7 @@ keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
 
 [dependencies]
-async-nats = "0.23"
+async-nats = "0.27"
 data-encoding = "2.3.3"
 ring = "0.16.20"
 cloudevents-sdk = "0.6.0"
@@ -24,4 +24,4 @@ serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 tracing = "0.1.37"
 tracing-futures = "0.2"
-wasmbus-rpc = { version = "0.11.2", features = [ "otel" ] }
+wasmbus-rpc = { version = "0.12", features = [ "otel" ]}


### PR DESCRIPTION
## Feature or Problem

This needed to be done anyway, but I was highly motivated so this can actually work in wadm.

Please note that I called this a new minor version because breaking the required NATS library (which we expose `client` as a parameter) seems breaking to me!
