### PR TITLE
update to wasmbus-rpc v0.13 and async-nats v0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"
@@ -13,7 +13,7 @@ keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
 
 [dependencies]
-async-nats = "0.27"
+async-nats = "0.29"
 data-encoding = "2.3.3"
 ring = "0.16.20"
 cloudevents-sdk = "0.6.0"
@@ -24,4 +24,4 @@ serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.60"
 tracing = "0.1.37"
 tracing-futures = "0.2"
-wasmbus-rpc = { version = "0.12", features = [ "otel" ]}
+wasmbus-rpc = { version = "0.13", features = [ "otel" ]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@ impl Client {
         {
             Err(_) => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out").into()),
             Ok(Ok(message)) => Ok(message),
-            Ok(Err(e)) => Err(e),
+            Ok(Err(e)) => Err(e.into()),
         }
     }
 


### PR DESCRIPTION
## Feature or Problem
This bumps wasmbus-rpc to v0.13 and async-nats to v0.29

## Related Issues
N/A

## Release Information
v0.25

## Consumer Impact
N/A

## Testing

### Manual Verification
Built wash with this version and tested control interface commands