### PR TITLE
feat!: add missing fields for host inventory and auction ack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"
@@ -13,7 +13,7 @@ keywords = ["webassembly", "wasm", "wasmcloud", "control", "ctl"]
 categories = ["wasm", "api-bindings"]
 
 [dependencies]
-async-nats = "0.30"
+async-nats = "0.31"
 data-encoding = "2.3.3"
 ring = "0.16.20"
 cloudevents-sdk = "0.7.0"

--- a/src/types.rs
+++ b/src/types.rs
@@ -9,6 +9,9 @@ pub struct ActorAuctionAck {
     /// The host ID of the "bidder" for this auction.
     #[serde(default)]
     pub host_id: String,
+    /// Constraints that were used in the auction
+    #[serde(default)]
+    pub constraints: HashMap<String, String>,
 }
 
 /// A request to locate suitable hosts for a given actor
@@ -119,6 +122,12 @@ pub struct HostInventory {
     /// The host's unique ID
     #[serde(default)]
     pub host_id: String,
+    /// The host's cluster issuer public key
+    #[serde(default)]
+    pub issuer: String,
+    /// The host's human-readable friendly name
+    #[serde(default)]
+    pub friendly_name: String,
     /// The host's labels
     pub labels: LabelsMap,
     /// Providers running on this host

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 /// One of a potential list of responses to an actor auction


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooks@cosmonic.com>

## Feature or Problem
We were missing a few fields that wasmCloud returns on the host inventory queries.

## Related Issues
Fixes #50 Fixes #51

## Release Information
v0.28.0 due to new available public fields. These structs should be backwards compatible as all of them will fall back on defaults.

## Consumer Impact
Consumers manually constructing these modified structs will have additional fields to fill in, which should only be wasmCloud hosts or wash.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
