### PR TITLE
fix(claims): safely parse null versions as empty string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,8 +228,8 @@ impl Client {
             debug!("get_claims:request {}", &subject);
             match self.request_timeout(subject, vec![], self.timeout).await {
                 Ok(msg) => {
-                    let list: GetClaimsResponse = json_deserialize(&msg.payload)?;
-                    Ok(list)
+                    let list: SafeClaimsResponse = json_deserialize(&msg.payload)?;
+                    Ok(list.into())
                 }
                 Err(e) => Err(format!("Did not receive claims from lattice: {}", e).into()),
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -77,6 +77,31 @@ pub struct GetClaimsResponse {
     pub claims: CtlKVList,
 }
 
+/// A safety type that can handle claims values that are set to Null. This is
+/// only used internally for compatibility, we will still send out [GetClaimsResponse]
+/// as the response type.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct SafeClaimsResponse {
+    pub claims: Vec<HashMap<String, Option<String>>>,
+}
+
+impl Into<GetClaimsResponse> for SafeClaimsResponse {
+    fn into(self) -> GetClaimsResponse {
+        GetClaimsResponse {
+            claims: self
+                .claims
+                .into_iter()
+                .map(|claim| {
+                    claim
+                        .into_iter()
+                        .map(|(k, v)| (k, v.unwrap_or_default()))
+                        .collect()
+                })
+                .collect(),
+        }
+    }
+}
+
 /// A summary representation of a host
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Host {


### PR DESCRIPTION
## Feature or Problem
This PR covers an edge case where hosts can store a version as a `Null` instead of an empty string, which breaks serialization. Now, instead of failing to deserialize, we can turn those Nulls into an empty string.

## Related Issues
I don't think it's filed directly but I've hit this issue using `wash spy` before.

## Release Information
v0.28.1

## Consumer Impact

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
I validated this will parse `null` versions.
