### PR TITLE
feat(*)!: deprecate start actor in favor of scale

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.29.0-rc.1"
+version = "0.30.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,3 @@
 This library is a convenient API for interacting with the lattice control interface. This is a Rust crate that implements the [lattice control protocol](https://wasmcloud.dev/reference/lattice-protocols/control-interface/) as described in the wasmCloud reference documentation. For a formal definition of the interface protocol, you can also look at the **Smithy** files in the [interface repository](https://github.com/wasmCloud/interfaces/blob/main/lattice-control/lattice-control-interface.smithy).
 
 The lattice control interface provides a way for clients to interact with the lattice to issue control commands and queries. This interface is a message broker protocol that supports functionality like starting and stopping actors and providers, declaring link definitions, monitoring lattice events, holding auctions to determine scheduling compatibility, and much more.
-
-## ⚠️ Host Runtime Compatibility
-
-This version of the control interface client uses some enhancements to the control protocol (such as _annotations_ and _provider configuration_) that require **v0.51.0** of the wasmCloud OTP host.

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -35,6 +35,7 @@ pub mod commands {
         since = "0.30.0",
         note = "Use `scale_actor` instead. This will be removed in a future release."
     )]
+    #[allow(dead_code)]
     pub fn start_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
         format!("{}.cmd.{}.la", prefix(topic_prefix, lattice_prefix), host) // la - launch actor
     }

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -31,6 +31,10 @@ pub mod commands {
     use super::prefix;
 
     /// Actor commands require a host target
+    #[deprecated(
+        since = "0.30.0",
+        note = "Use `scale_actor` instead. This will be removed in a future release."
+    )]
     pub fn start_actor(topic_prefix: &Option<String>, lattice_prefix: &str, host: &str) -> String {
         format!("{}.cmd.{}.la", prefix(topic_prefix, lattice_prefix), host) // la - launch actor
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,13 @@ impl<T> ClientBuilder<T> {
     }
 
     /// Sets the timeout for standard calls and RPC invocations used by the client. If not set, the default will be 2 seconds
+    #[deprecated(since = "0.30.0", note = "please use `timeout` instead")]
     pub fn rpc_timeout(self, timeout: Duration) -> ClientBuilder<T> {
+        ClientBuilder { timeout, ..self }
+    }
+
+    /// Sets the timeout for control interface requests issued by the client. If not set, the default will be 2 seconds
+    pub fn timeout(self, timeout: Duration) -> ClientBuilder<T> {
         ClientBuilder { timeout, ..self }
     }
 
@@ -784,7 +790,7 @@ mod tests {
     async fn test_events_receiver() {
         let nc = async_nats::connect("127.0.0.1:4222").await.unwrap();
         let client = ClientBuilder::new(nc)
-            .rpc_timeout(Duration::from_millis(1000))
+            .timeout(Duration::from_millis(1000))
             .auction_timeout(Duration::from_millis(1000))
             .build()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,21 +305,21 @@ impl<T: KvStore + Clone + Debug + Send + Sync> Client<T> {
     /// # Arguments
     /// `host_id`: The ID of the host to scale the actor on
     /// `actor_ref`: The OCI reference of the actor to scale
-    /// `max`: The maximum number of instances this actor can run concurrently. Setting this value to 0 means there is no maximum.
+    /// `max_concurrent`: The maximum number of instances this actor can run concurrently. Setting this value to 0 means there is no maximum.
     /// `annotations`: Optional annotations to apply to the actor
     #[instrument(level = "debug", skip_all)]
     pub async fn scale_actor(
         &self,
         host_id: &str,
         actor_ref: &str,
-        max: u16,
+        max_concurrent: u16,
         annotations: Option<HashMap<String, String>>,
     ) -> Result<CtlOperationAck> {
         let subject =
             broker::commands::scale_actor(&self.topic_prefix, &self.lattice_prefix, host_id);
         debug!("scale_actor:request {}", &subject);
         let bytes = json_serialize(ScaleActorCommand {
-            max,
+            max_concurrent,
             actor_ref: actor_ref.to_string(),
             host_id: host_id.to_string(),
             annotations,

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,12 +52,18 @@ pub struct ActorInstance {
     /// this actor instance
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
+    /// Image reference for this actor, if applicable
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_ref: Option<String>,
     /// This instance's unique ID (guid)
     #[serde(default)]
     pub instance_id: String,
     /// The revision number for this actor instance
     #[serde(default)]
     pub revision: i32,
+    /// The maximum number of concurrent requests this instance can handle
+    #[serde(default)]
+    pub max_concurrent: u16,
 }
 
 pub type AnnotationMap = std::collections::HashMap<String, String>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -227,24 +227,27 @@ pub struct RemoveLinkDefinitionRequest {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ScaleActorCommand {
-    /// Public Key ID of the actor to scale
-    #[serde(default)]
-    pub actor_id: String,
-    /// Reference for the actor. Can be any of the acceptable forms of unique identification
+    /// Image reference for the actor.
     #[serde(default)]
     pub actor_ref: String,
     /// Optional set of annotations used to describe the nature of this actor scale command. For
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
-    /// The target number of actors
-    #[serde(default)]
-    pub count: u16,
+    /// The maximum number of concurrent executing instances of this actor. If omitted or set to
+    /// zero there is no maximum.
+    // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
+    #[serde(default, alias = "count", rename = "count")]
+    pub max_concurrent: u16,
     /// Host ID on which to scale this actor
     #[serde(default)]
     pub host_id: String,
 }
 
+#[deprecated(
+    since = "0.30.0",
+    note = "Use `ScaleActorCommand` instead. This will be removed in a future release."
+)]
 /// A command sent to a specific host instructing it to start the actor
 /// indicated by the reference.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -302,10 +305,6 @@ pub struct StopActorCommand {
     /// annotations will be stopped
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
-    /// The number of actors to stop
-    /// A zero value means stop all actors
-    #[serde(default)]
-    pub count: u16,
     /// The ID of the target host
     #[serde(default)]
     pub host_id: String,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};

--- a/src/types.rs
+++ b/src/types.rs
@@ -152,6 +152,9 @@ pub struct ProviderAuctionAck {
     /// The original provider ref provided for the auction
     #[serde(default)]
     pub provider_ref: String,
+    /// The constraints provided for the auction
+    #[serde(default)]
+    pub constraints: HashMap<String, String>,
 }
 
 /// A request to locate a suitable host for a capability provider. The


### PR DESCRIPTION
## Feature or Problem
This PR makes a few changes to deprecate the `start_actor` command in favor of `scale_actor` and renames mentions of `count` to `max` or `max_concurrent` after discussion in the RFC.

## Related Issues
RFC https://github.com/wasmCloud/wasmCloud/issues/696

## Release Information
I slated this for `0.30.0` but considering 0.29.0 isn't even out yet, I can bump back to 0.29.0.

## Consumer Impact
The breaking change in this PR is additional backwards-compatible functionality, the removal of `actor_id` from the `scale_actor` command, removing `count` from the `stop_actor` command, and additional fields in some commands that would break if you're directly instantiating structs without using the `..` operator.

Please note that each removed field has `#[serde(default)]` on it, meaning that this PR change is over-the-wire forwards and backwards compatible.

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
