### PR TITLE
fix(max)!: make max optional, change meaning of 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.29.0"
+version = "0.29.1"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,11 +244,11 @@ pub struct ScaleActorCommand {
     /// example, autonomous agents may wish to "tag" scale requests as part of a given deployment
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<AnnotationMap>,
-    /// The maximum number of concurrent executing instances of this actor. If omitted or set to
-    /// zero there is no maximum.
+    /// The maximum number of concurrent executing instances of this actor. If set to `None` there
+    /// there is no maximum, while setting to `0` will stop the actor.
     // NOTE: renaming to `count` lets us remain backwards compatible for a few minor versions
     #[serde(default, alias = "count", rename = "count")]
-    pub max_concurrent: u16,
+    pub max_concurrent: Option<u16>,
     /// Host ID on which to scale this actor
     #[serde(default)]
     pub host_id: String,


### PR DESCRIPTION
## Feature or Problem
This PR addresses an oversight in 0.29.0 that affected backwards compatibility where setting a max of `0` would represent unbounded concurrency. Instead, we will set the max field with scale to an `Option<u16>`, where `0` represents stopping the actor and `None` means unbounded.

This does mean that by using this version of the control interface and supplying a `None` maximum concurrency, current versions of the host will interpret that as stopping the actor. This is no change from supplying `0`.

## Related Issues
#56 

## Release Information
v0.29.1

## Consumer Impact
**v0.29.0 should be yanked from crates.io**

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
