### PR TITLE
fix: add friendly_name to Host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.29.1"
+version = "0.29.2"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/src/types.rs
+++ b/src/types.rs
@@ -87,6 +87,9 @@ pub struct Host {
     /// NATS server host used for the control interface
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ctl_host: Option<String>,
+    /// Human-friendly name for this host
+    #[serde(default)]
+    pub friendly_name: String,
     #[serde(default)]
     pub id: String,
     /// JetStream domain (if applicable) in use by this host
@@ -136,7 +139,6 @@ pub struct HostInventory {
     pub providers: ProviderDescriptions,
 }
 
-pub type Hosts = Vec<Host>;
 pub type KeyValueMap = std::collections::HashMap<String, String>;
 pub type LabelsMap = std::collections::HashMap<String, String>;
 


### PR DESCRIPTION
This adds the `friendly_name` to the `Host` struct. Note that the host has been including this information in its responses, we just weren't parsing it.

This is needed for https://github.com/wasmCloud/wash/issues/613