### PR TITLE
fix(caching): Fixes issue with cached links not populating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-control-interface"
-version = "0.29.2"
+version = "0.30.0"
 authors = ["wasmCloud Team"]
 edition = "2021"
 homepage = "https://wasmcloud.com"

--- a/src/kv/direct.rs
+++ b/src/kv/direct.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use tracing::{debug, error};
 
 use super::{
-    delete_link, ld_hash_raw, put_link, KvStore, CLAIMS_PREFIX, LINKDEF_PREFIX, SUBJECT_KEY,
+    delete_link, ld_hash_raw, put_link, Build, KvStore, CLAIMS_PREFIX, LINKDEF_PREFIX, SUBJECT_KEY,
 };
 use crate::{types::LinkDefinition, Result};
 
@@ -127,6 +127,13 @@ impl DirectKvStore {
                 _ => None,
             })
             .collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Build for DirectKvStore {
+    async fn build(nc: Client, lattice_prefix: &str, js_domain: Option<String>) -> Result<Self> {
+        Self::new(nc, lattice_prefix, js_domain).await
     }
 }
 

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -24,9 +24,7 @@ pub struct OtelHeaderExtractor<'a> {
 
 impl<'a> Extractor for OtelHeaderExtractor<'a> {
     fn get(&self, key: &str) -> Option<&str> {
-        self.inner
-            .get(key)
-            .and_then(|s| s.iter().next().map(|s| s.as_str()))
+        self.inner.get(key).map(|s| s.as_str())
     }
 
     fn keys(&self) -> Vec<&str> {


### PR DESCRIPTION
The initial implementation of the cached KV client had issues due to the drop implementation for the caching thread. It was only behind and arc, so any time a clone was dropped, the thread would stop polling.

This also adds some additional logging around the caching and fixes the client builder based off of real life usage in wadm
