### PR TITLE
chore!: remove prov_rpc_host

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -101,9 +101,6 @@ pub struct Host {
     /// Lattice prefix/ID used by the host
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lattice_prefix: Option<String>,
-    /// NATS server host used for provider RPC
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub prov_rpc_host: Option<String>,
     /// NATS server host used for regular RPC
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rpc_host: Option<String>,


### PR DESCRIPTION
## Feature or Problem
The host is dropping support for a separate `prov_rpc` NATS connection. See https://github.com/wasmCloud/wasmCloud/pull/774 for motivation

## Related Issues
https://github.com/wasmCloud/wasmCloud/pull/774

## Release Information
v0.31.0, since this is a compile-time breaking change

## Consumer Impact
Since the field is optional in this client, the host can stop sending data before consumers of this crate are updated

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
